### PR TITLE
replace non-ASCII character \xe2

### DIFF
--- a/model.py
+++ b/model.py
@@ -58,8 +58,8 @@ def train_doc2vec(corpus):
                           workers=5,  # Number of worker threads to train the model
                           alpha=0.025,  # The initial learning rate
                           min_alpha=0.00025,  # Learning rate will linearly drop to min_alpha as training progresses
-                          dm=1)  # dm defines the training algorithm. If dm=1 means ‘distributed memory’ (PV-DM)
-                                 # and dm =0 means ‘distributed bag of words’ (PV-DBOW)
+                          dm=1)  # dm defines the training algorithm. If dm=1 means 'distributed memory' (PV-DM)
+                                 # and dm =0 means 'distributed bag of words' (PV-DBOW)
     d2v.build_vocab(corpus)
 
     logging.info("Training Doc2Vec model")


### PR DESCRIPTION
On macOS (Python 2.7) following error is shown:
SyntaxError: Non-ASCII character '\xe2' in file model.py on line 61, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

After replacing this character in the comments of line 61 and 62 everything is fine.